### PR TITLE
Refactored Tests and Formatting

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -45,7 +45,9 @@ end
 #
 
 @view
-func assert_only_self{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
+func assert_only_self{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}():
     let (self) = address.read()
     let (caller) = get_caller_address()
     assert self = caller
@@ -53,7 +55,9 @@ func assert_only_self{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_ch
 end
 
 @view
-func assert_initialized{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
+func assert_initialized{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}():
     let (_initialized) = initialized.read()
     assert _initialized = 1
     return ()
@@ -64,21 +68,25 @@ end
 #
 
 @view
-func get_public_key{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-        res : felt):
+func get_public_key{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (res: felt):
     let (res) = public_key.read()
     return (res=res)
 end
 
 @view
-func get_address{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (
-        res : felt):
+func get_address{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res: felt):
     let (res) = address.read()
     return (res=res)
 end
 
 @view
-func get_nonce{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}() -> (res : felt):
+func get_nonce{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} () -> (res: felt):
     let (res) = current_nonce.read()
     return (res=res)
 end
@@ -88,8 +96,9 @@ end
 #
 
 @external
-func set_public_key{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        new_public_key : felt):
+func set_public_key{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (new_public_key: felt):
     assert_only_self()
     public_key.write(new_public_key)
     return ()
@@ -100,8 +109,9 @@ end
 #
 
 @external
-func initialize{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        _public_key : felt, _address : felt):
+func initialize{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr} (_public_key: felt, _address: felt):
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -116,12 +126,17 @@ end
 
 @view
 func is_valid_signature{
-        pedersen_ptr : HashBuiltin*, ecdsa_ptr : SignatureBuiltin*, syscall_ptr : felt*,
-        range_check_ptr}(hash : felt, signature_len : felt, signature : felt*) -> ():
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr, ecdsa_ptr: SignatureBuiltin*} (
+        hash: felt,
+        signature_len: felt,
+        signature: felt*
+    ) -> ():
     alloc_locals
     assert_initialized()
     let (_public_key) = public_key.read()
     local syscall_ptr : felt* = syscall_ptr
+
     # This interface expects a signature pointer and length to make
     # no assumption about signature validation schemes.
     # But this implementation does, and it expects a (sig_r, sig_s) pair.
@@ -129,17 +144,25 @@ func is_valid_signature{
     let sig_s = signature[1]
 
     verify_ecdsa_signature(
-        message=hash, public_key=_public_key, signature_r=sig_r, signature_s=sig_s)
+        message=hash,
+        public_key=_public_key,
+        signature_r=sig_r,
+        signature_s=sig_s)
 
     return ()
 end
 
 @external
 func execute{
-        pedersen_ptr : HashBuiltin*, ecdsa_ptr : SignatureBuiltin*, syscall_ptr : felt*,
-        range_check_ptr}(
-        to : felt, selector : felt, calldata_len : felt, calldata : felt*, signature_len : felt,
-        signature : felt*) -> (response : felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr, ecdsa_ptr: SignatureBuiltin*} (
+        to: felt,
+        selector: felt,
+        calldata_len: felt,
+        calldata: felt*,
+        signature_len: felt,
+        signature: felt*
+    ) -> (response : felt):
     alloc_locals
     assert_initialized()
 
@@ -158,7 +181,7 @@ func execute{
         calldata,
         calldata_size=calldata_len,
         _current_nonce
-        )
+    )
 
     # validate transaction
     let (hash) = hash_message(&message)
@@ -190,8 +213,10 @@ func hash_message{pedersen_ptr : HashBuiltin*}(message : Message*) -> (res : fel
     return (res=res)
 end
 
-func hash_calldata{pedersen_ptr : HashBuiltin*}(calldata : felt*, calldata_size : felt) -> (
-        res : felt):
+func hash_calldata{pedersen_ptr : HashBuiltin*}(
+        calldata : felt*, 
+        calldata_size : felt
+    ) -> (res : felt):
     if calldata_size == 0:
         return (res=0)
     end

--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -47,7 +47,7 @@ end
 @view
 func assert_only_self{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}():
+        range_check_ptr} ():
     let (self) = address.read()
     let (caller) = get_caller_address()
     assert self = caller
@@ -57,7 +57,7 @@ end
 @view
 func assert_initialized{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}():
+        range_check_ptr} ():
     let (_initialized) = initialized.read()
     assert _initialized = 1
     return ()
@@ -70,7 +70,7 @@ end
 @view
 func get_public_key{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}() -> (res: felt):
+        range_check_ptr} () -> (res: felt):
     let (res) = public_key.read()
     return (res=res)
 end
@@ -147,7 +147,8 @@ func is_valid_signature{
         message=hash,
         public_key=_public_key,
         signature_r=sig_r,
-        signature_s=sig_s)
+        signature_s=sig_s
+    )
 
     return ()
 end

--- a/contracts/AddressRegistry.cairo
+++ b/contracts/AddressRegistry.cairo
@@ -11,7 +11,7 @@ end
 @external
 func get_L1_address{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}(L2_address: felt) -> (res: felt):
+        range_check_ptr} (L2_address: felt) -> (res: felt):
     let (res) = L1_address.read(L2_address)
     return (res=res)
 end
@@ -19,7 +19,7 @@ end
 @external
 func set_L1_address{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}(new_L1_address: felt):
+        range_check_ptr} (new_L1_address: felt):
     let (caller) = get_caller_address()
     L1_address.write(caller, new_L1_address)
     return ()

--- a/contracts/AddressRegistry.cairo
+++ b/contracts/AddressRegistry.cairo
@@ -3,7 +3,6 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
-from starkware.starknet.common.storage import Storage
 
 @storage_var
 func L1_address(L2_address: felt) -> (res: felt):
@@ -11,21 +10,16 @@ end
 
 @external
 func get_L1_address{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    }(L2_address: felt) -> (res: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}(L2_address: felt) -> (res: felt):
     let (res) = L1_address.read(L2_address)
     return (res=res)
 end
 
 @external
 func set_L1_address{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }(new_L1_address: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}(new_L1_address: felt):
     let (caller) = get_caller_address()
     L1_address.write(caller, new_L1_address)
     return ()

--- a/contracts/Initializable.cairo
+++ b/contracts/Initializable.cairo
@@ -2,20 +2,23 @@
 %builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
 
 @storage_var
 func _initialized() -> (res: felt):
 end
 
 @external
-func initialized{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func initialized{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}() -> (res: felt):
     let (res) = _initialized.read()
     return (res=res)
 end
 
 @external
-func initialize{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }():
+func initialize{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}():
     let (initialized) = _initialized.read()
     assert initialized = 0
     _initialized.write(1)

--- a/contracts/Initializable.cairo
+++ b/contracts/Initializable.cairo
@@ -10,7 +10,7 @@ end
 @external
 func initialized{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}() -> (res: felt):
+        range_check_ptr} () -> (res: felt):
     let (res) = _initialized.read()
     return (res=res)
 end
@@ -18,7 +18,7 @@ end
 @external
 func initialize{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}():
+        range_check_ptr} ():
     let (initialized) = _initialized.read()
     assert initialized = 0
     _initialized.write(1)

--- a/contracts/Ownable.cairo
+++ b/contracts/Ownable.cairo
@@ -1,7 +1,6 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
 from starkware.starknet.common.syscalls import get_caller_address
 from contracts.Initializable import initialized, initialize
 
@@ -9,20 +8,18 @@ from contracts.Initializable import initialized, initialize
 func _owner() -> (res: felt):
 end
 
-
 @view
-func get_owner{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+func get_owner{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}() -> (res: felt):
     let (res) = _owner.read()
     return (res=res)
 end
 
 @view
 func only_owner{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    }():
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}():
     let (owner) = _owner.read()
     let (caller) = get_caller_address()
     assert owner = caller
@@ -31,10 +28,8 @@ end
 
 @external
 func initialize_ownable{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        range_check_ptr
-    } (initial_owner: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}(initial_owner: felt):
     initialize()
     _owner.write(initial_owner)
     return ()
@@ -42,11 +37,8 @@ end
 
 @external
 func transfer_ownership{
-        storage_ptr: Storage*,
-        pedersen_ptr: HashBuiltin*,
-        syscall_ptr: felt*,
-        range_check_ptr
-    } (new_owner: felt) -> (new_owner: felt):
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr}(new_owner: felt) -> (new_owner: felt):
     only_owner()
     _owner.write(new_owner)
     return (new_owner=new_owner)

--- a/contracts/Ownable.cairo
+++ b/contracts/Ownable.cairo
@@ -11,7 +11,7 @@ end
 @view
 func get_owner{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}() -> (res: felt):
+        range_check_ptr} () -> (res: felt):
     let (res) = _owner.read()
     return (res=res)
 end
@@ -19,7 +19,7 @@ end
 @view
 func only_owner{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}():
+        range_check_ptr} ():
     let (owner) = _owner.read()
     let (caller) = get_caller_address()
     assert owner = caller
@@ -29,7 +29,7 @@ end
 @external
 func initialize_ownable{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}(initial_owner: felt):
+        range_check_ptr} (initial_owner: felt):
     initialize()
     _owner.write(initial_owner)
     return ()
@@ -38,7 +38,7 @@ end
 @external
 func transfer_ownership{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}(new_owner: felt) -> (new_owner: felt):
+        range_check_ptr} (new_owner: felt) -> (new_owner: felt):
     only_owner()
     _owner.write(new_owner)
     return (new_owner=new_owner)

--- a/contracts/contract.cairo
+++ b/contracts/contract.cairo
@@ -14,7 +14,7 @@ end
 @external
 func increase_balance{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}(amount : felt):
+        range_check_ptr} (amount : felt):
     let (res) = balance.read()
     balance.write(res + amount)
     return ()
@@ -24,7 +24,7 @@ end
 @view
 func get_balance{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
-        range_check_ptr}() -> (res : felt):
+        range_check_ptr} () -> (res : felt):
     let (res) = balance.read()
     return (res)
 end

--- a/contracts/contract.cairo
+++ b/contracts/contract.cairo
@@ -4,7 +4,6 @@
 %builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
 
 # Define a storage variable.
 @storage_var
@@ -14,7 +13,7 @@ end
 # Increases the balance by the given amount.
 @external
 func increase_balance{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*,
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
         range_check_ptr}(amount : felt):
     let (res) = balance.read()
     balance.write(res + amount)
@@ -24,7 +23,7 @@ end
 # Returns the current balance.
 @view
 func get_balance{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*,
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
         range_check_ptr}() -> (res : felt):
     let (res) = balance.read()
     return (res)

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -163,8 +163,8 @@ end
 
 @external
 func decrease_allowance{
-        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr
-        } (spender : felt, subtracted_value : felt):
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} (spender : felt, subtracted_value : felt):
     let (caller) = get_caller_address()
     let (current_allowance) = allowances.read(owner=caller, spender=spender)
     # checks that the decreased balance isn't below zero

--- a/contracts/token/ERC20.cairo
+++ b/contracts/token/ERC20.cairo
@@ -34,29 +34,33 @@ end
 #
 
 @view
-func get_total_supply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        res : felt):
+func get_total_supply{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr} () -> (res : felt):
     let (res) = total_supply.read()
     return (res)
 end
 
 @view
-func get_decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        res : felt):
+func get_decimals{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr} () -> (res : felt):
     let (res) = decimals.read()
     return (res)
 end
 
 @view
-func balance_of{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(user : felt) -> (
-        res : felt):
+func balance_of{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr} (user : felt) -> (res : felt):
     let (res) = balances.read(user=user)
     return (res)
 end
 
 @view
-func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        owner : felt, spender : felt) -> (res : felt):
+func allowance{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr} (owner : felt, spender : felt) -> (res : felt):
     let (res) = allowances.read(owner=owner, spender=spender)
     return (res)
 end
@@ -66,7 +70,9 @@ end
 #
 
 @external
-func initialize{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}():
+func initialize{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} ():
     let (_initialized) = initialized.read()
     assert _initialized = 0
     initialized.write(1)
@@ -77,8 +83,9 @@ func initialize{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_pt
     return ()
 end
 
-func _mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        recipient : felt, amount : felt):
+func _mint{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} (recipient : felt, amount : felt):
     let (res) = balances.read(user=recipient)
     balances.write(recipient, res + amount)
 
@@ -87,8 +94,9 @@ func _mint{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
     return ()
 end
 
-func _transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        sender : felt, recipient : felt, amount : felt):
+func _transfer{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
+        range_check_ptr} (sender : felt, recipient : felt, amount : felt):
     # validate sender has enough funds
     let (sender_balance) = balances.read(user=sender)
     assert_nn_le(amount, sender_balance)
@@ -102,23 +110,26 @@ func _transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     return ()
 end
 
-func _approve{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        caller : felt, spender : felt, amount : felt):
+func _approve{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} (caller : felt, spender : felt, amount : felt):
     allowances.write(caller, spender, amount)
     return ()
 end
 
 @external
-func transfer{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        recipient : felt, amount : felt):
+func transfer{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} (recipient : felt, amount : felt):
     let (sender) = get_caller_address()
     _transfer(sender, recipient, amount)
     return ()
 end
 
 @external
-func transfer_from{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        sender : felt, recipient : felt, amount : felt):
+func transfer_from{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} (sender : felt, recipient : felt, amount : felt):
     let (caller) = get_caller_address()
     let (caller_allowance) = allowances.read(owner=sender, spender=caller)
     assert_nn_le(amount, caller_allowance)
@@ -128,16 +139,18 @@ func transfer_from{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check
 end
 
 @external
-func approve{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        spender : felt, amount : felt):
+func approve{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} (spender : felt, amount : felt):
     let (caller) = get_caller_address()
     _approve(caller, spender, amount)
     return ()
 end
 
 @external
-func increase_allowance{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        spender : felt, added_value : felt):
+func increase_allowance{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, 
+        range_check_ptr} (spender : felt, added_value : felt):
     let (caller) = get_caller_address()
     let (current_allowance) = allowances.read(caller, spender)
     # using a tempvar for internal check
@@ -149,8 +162,9 @@ func increase_allowance{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_
 end
 
 @external
-func decrease_allowance{pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr}(
-        spender : felt, subtracted_value : felt):
+func decrease_allowance{
+        pedersen_ptr : HashBuiltin*, syscall_ptr : felt*, range_check_ptr
+        } (spender : felt, subtracted_value : felt):
     let (caller) = get_caller_address()
     let (current_allowance) = allowances.read(owner=caller, spender=spender)
     # checks that the decreased balance isn't below zero

--- a/test/Account.py
+++ b/test/Account.py
@@ -25,8 +25,12 @@ async def account_factory():
 @pytest.mark.asyncio
 async def test_initializer(account_factory):
     _, account = account_factory
-    assert await account.get_public_key().call() == (signer.public_key,)
-    assert await account.get_address().call() == (account.contract_address,)
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (signer.public_key,)
+
+    execution_info = await account.get_address().call()
+    assert execution_info.result == (account.contract_address,)
 
 
 @pytest.mark.asyncio
@@ -34,16 +38,22 @@ async def test_execute(account_factory):
     starknet, account = account_factory
     initializable = await starknet.deploy("contracts/Initializable.cairo")
 
-    assert await initializable.initialized().call() == (0,)
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (0,)
+
+    # initialize
     await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
-    assert await initializable.initialized().call() == (1,)
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (1,)
 
 
 @pytest.mark.asyncio
 async def test_nonce(account_factory):
     starknet, account = account_factory
     initializable = await starknet.deploy("contracts/Initializable.cairo")
-    current_nonce, = await account.get_nonce().call()
+    execution_info = await account.get_nonce().call()
+    current_nonce = execution_info.result.res
 
     # lower nonce
     try:
@@ -60,15 +70,22 @@ async def test_nonce(account_factory):
     except StarkException as err:
         _, error = err.args
         assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
-
     # right nonce
     await signer.send_transaction(account, initializable.contract_address, 'initialize', [], current_nonce)
-    assert await initializable.initialized().call() == (1,)
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (1,)
 
 
 @pytest.mark.asyncio
 async def test_public_key_setter(account_factory):
     _, account = account_factory
-    assert await account.get_public_key().call() == (signer.public_key,)
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (signer.public_key,)
+
+    # set new pubkey
     await signer.send_transaction(account, account.contract_address, 'set_public_key', [other.public_key])
-    assert await account.get_public_key().call() == (other.public_key,)
+
+    execution_info = await account.get_public_key().call()
+    assert execution_info.result == (other.public_key,)

--- a/test/AddressRegistry.py
+++ b/test/AddressRegistry.py
@@ -27,7 +27,9 @@ async def test_set_address(account_factory):
     _, account, registry = account_factory
 
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
-    assert await registry.get_L1_address(account.contract_address).call() == (L1_ADDRESS,)
+    # assert await registry.get_L1_address(account.contract_address).call() == (L1_ADDRESS,)
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
 
 
 @pytest.mark.asyncio
@@ -35,7 +37,12 @@ async def test_update_address(account_factory):
     _, account, registry = account_factory
 
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [L1_ADDRESS])
-    assert await registry.get_L1_address(account.contract_address).call() == (L1_ADDRESS,)
 
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
+
+    # set new address
     await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [ANOTHER_ADDRESS])
-    assert await registry.get_L1_address(account.contract_address).call() == (ANOTHER_ADDRESS,)
+
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (ANOTHER_ADDRESS,)

--- a/test/ERC20.py
+++ b/test/ERC20.py
@@ -26,8 +26,11 @@ async def erc20_factory():
 @pytest.mark.asyncio
 async def test_initializer(erc20_factory):
     _, erc20, account = erc20_factory
-    assert await erc20.balance_of(account.contract_address).call() == (1000,)
-    assert await erc20.get_total_supply().call() == (1000,)
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (1000,)
+
+    execution_info = await erc20.get_total_supply().call()
+    assert execution_info.result == (1000,)
 
 
 @pytest.mark.asyncio
@@ -35,20 +38,33 @@ async def test_transfer(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
     amount = 100
-    (previous_supply,) = await erc20.get_total_supply().call()
-    assert await erc20.balance_of(account.contract_address).call() == (1000,)
-    assert await erc20.balance_of(recipient).call() == (0,)
+    execution_info = await erc20.get_total_supply().call()
+    previous_supply = execution_info.result
+
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (1000,)
+
+    execution_info = await erc20.balance_of(recipient).call()
+    assert execution_info.result == (0,)
+
     await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, amount])
-    assert await erc20.balance_of(account.contract_address).call() == (900,)
-    assert await erc20.balance_of(recipient).call() == (100,)
-    assert (previous_supply,) == await erc20.get_total_supply().call()
+
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (900,)
+
+    execution_info = await erc20.balance_of(recipient).call()
+    assert execution_info.result == (100,)
+
+    execution_info = await erc20.get_total_supply().call()
+    assert execution_info.result == previous_supply
 
 
 @pytest.mark.asyncio
 async def test_insufficient_sender_funds(erc20_factory):
     _, erc20, account = erc20_factory
     recipient = 123
-    (balance,) = await erc20.balance_of(account.contract_address).call()
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    balance = execution_info.result.res
 
     try:
         await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient, balance + 1])
@@ -63,9 +79,15 @@ async def test_approve(erc20_factory):
     _, erc20, account = erc20_factory
     spender = 123
     amount = 345
-    assert await erc20.allowance(account.contract_address, spender).call() == (0,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (0,)
+
+    # set approval
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (amount,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (amount,)
 
 
 @pytest.mark.asyncio
@@ -77,15 +99,21 @@ async def test_transfer_from(erc20_factory):
     await spender.initialize(signer.public_key, spender.contract_address).invoke()
     amount = 345
     recipient = 987
-    (previous_balance,) = await erc20.balance_of(account.contract_address).call()
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    previous_balance = execution_info.result.res
 
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, amount])
     await signer.send_transaction(spender, erc20.contract_address, 'transfer_from',
                                   [account.contract_address, recipient, amount])
 
-    assert await erc20.balance_of(account.contract_address).call() == (previous_balance - amount,)
-    assert await erc20.balance_of(recipient).call() == (amount,)
-    assert await erc20.allowance(account.contract_address, spender.contract_address).call() == (0,)
+    execution_info = await erc20.balance_of(account.contract_address).call()
+    assert execution_info.result == (previous_balance - amount,)
+
+    execution_info = await erc20.balance_of(recipient).call()
+    assert execution_info.result == (amount,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender.contract_address).call()
+    assert execution_info.result == (0,)
 
 
 @pytest.mark.asyncio
@@ -94,13 +122,21 @@ async def test_increase_allowance(erc20_factory):
     # new spender, starting from zero
     spender = 234
     amount = 345
-    assert await erc20.allowance(account.contract_address, spender).call() == (0,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (0,)
+
+    # set approve
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (amount,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (amount,)
 
     # increase allowance
     await signer.send_transaction(account, erc20.contract_address, 'increase_allowance', [spender, amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (amount * 2,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (amount * 2,)
 
 
 @pytest.mark.asyncio
@@ -111,12 +147,21 @@ async def test_decrease_allowance(erc20_factory):
     init_amount = 345
     subtract_amount = 100
     new_amount = 245
-    assert await erc20.allowance(account.contract_address, spender).call() == (0,)
-    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (init_amount,)
 
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (0,)
+
+    # set approve
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (init_amount,)
+
+    # decrease allowance
     await signer.send_transaction(account, erc20.contract_address, 'decrease_allowance', [spender, subtract_amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (new_amount,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (init_amount - subtract_amount,)
 
 
 @pytest.mark.asyncio
@@ -126,7 +171,9 @@ async def test_decrease_allowance_below_zero(erc20_factory):
     spender = 987
     init_amount = 345
     await signer.send_transaction(account, erc20.contract_address, 'approve', [spender, init_amount])
-    assert await erc20.allowance(account.contract_address, spender).call() == (345,)
+
+    execution_info = await erc20.allowance(account.contract_address, spender).call()
+    assert execution_info.result == (init_amount,)
 
     try:
         # increasing the decreased allowance amount by more than the user's allowance
@@ -146,10 +193,9 @@ async def test_transfer_funds_greater_than_allowance(erc20_factory):
     await spender.initialize(signer.public_key, spender.contract_address).invoke()
     recipient = 222
     allowance = 111
+    await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, allowance])
 
-    # executing the same transactions with transfer amount greater than allowance
     try:
-        await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, allowance])
         # increasing the transfer amount above allowance
         await signer.send_transaction(spender, erc20.contract_address, 'transfer_from', [account.contract_address, recipient, allowance + 1])
         assert False
@@ -173,4 +219,3 @@ async def test_overflow_increase_allowance(erc20_factory):
     except StarkException as err:
         _, error = err.args
         assert error['code'] == StarknetErrorCode.TRANSACTION_FAILED
- 

--- a/test/Initializable.py
+++ b/test/Initializable.py
@@ -6,6 +6,10 @@ from starkware.starknet.testing.starknet import Starknet
 async def test_initializer():
     starknet = await Starknet.empty()
     initializable = await starknet.deploy("contracts/Initializable.cairo")
-    assert await initializable.initialized().call() == (0,)
+    expected = await initializable.initialized().call()
+    assert expected.result == (0,)
+
     await initializable.initialize().invoke()
-    assert await initializable.initialized().call() == (1,)
+
+    expected = await initializable.initialized().call()
+    assert expected.result == (1,)

--- a/test/Ownable.py
+++ b/test/Ownable.py
@@ -24,7 +24,8 @@ async def ownable_factory():
 @pytest.mark.asyncio
 async def test_initializer(ownable_factory):
     _, ownable, owner = ownable_factory
-    assert await ownable.get_owner().call() == (owner.contract_address,)
+    executed_info = await ownable.get_owner().call()
+    assert executed_info.result.res == owner.contract_address
 
 
 @pytest.mark.asyncio
@@ -32,4 +33,6 @@ async def test_transfer_ownership(ownable_factory):
     _, ownable, owner = ownable_factory
     new_owner = 123
     await signer.send_transaction(owner, ownable.contract_address, 'transfer_ownership', [new_owner])
-    assert await ownable.get_owner().call() == (new_owner,)
+
+    executed_info = await ownable.get_owner().call()
+    assert executed_info.result == (new_owner,)


### PR DESCRIPTION

# Refactored Tests for Cairo's 0.5.0 Update

## Summary
Building upon @RoboTeddy 's work with Account.cairo and ERC20.cairo contracts, this PR includes the rest of the Cairo contracts refactored (sans ERC721), the entire test suite refactored/passing, and reformatted contracts.

## Implementation
- Contract calls now return an object; therefore, assertions must now unpack the result using dot notation. For example:
-- (old) `assert await foo().call() == (0,)`
-- (new) `execution_info = await foo().call() \n assert execution_info.result == (0,)`